### PR TITLE
add max size to index out of range panic

### DIFF
--- a/src/bitset.rs
+++ b/src/bitset.rs
@@ -244,7 +244,11 @@ impl<Conf: Config> BitSet<Conf> {
     ///
     /// Panics, if `index` is out of index range.
     pub fn insert(&mut self, index: usize){
-        assert!(Self::is_in_range(index), "{index} is out of index range!");
+        assert!(
+            Self::is_in_range(index),
+            "{index} is out of index range (max={})!"
+            Self::max_capacity(),
+        );
 
         // That's indices to next level
         let (level0_index, level1_index, data_index) = Self::level_indices(index);


### PR DESCRIPTION
Nice work, just trying out this library. However, ran into some problems with finding the `max_capacity` for 64-bit sets. One could consider adding it to the panic messages.

I can also see some asserts sprinkled around with just about the same message as well, but did not touch them, considering that proper error handling might be anyways implemented in the future.  

Cheers.

p.s. No idea why line 395 shows here in the diff. 