### PR TITLE
Add large bitset deserialization test

### DIFF
--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,14 @@
+use rand::{thread_rng, Rng};
+
+type BitSet = hi_sparse_bitset::BitSet<hi_sparse_bitset::config::_256bit>;
+
+#[test]
+fn serde() {
+    let mut rng = thread_rng();
+    let bitset: BitSet = (0..BitSet::max_capacity())
+        .filter(|_| rng.gen())
+        .collect();
+    let mut buffer = Vec::new();
+    bitset.serialize(&mut buffer).unwrap();
+    assert_eq!(bitset, BitSet::deserialize(&mut buffer.as_slice()).unwrap());
+}


### PR DESCRIPTION
Attempting to deserialize a large BitSet fails:

```
thread 'serde' panicked at /home/louis/Projects/hi_sparse_bitset/src/bitset/serialization.rs:32:13:
attempt to add with overflow
```